### PR TITLE
Improve kernel-install hook

### DIFF
--- a/pacman-hook-kernel-install/.SRCINFO
+++ b/pacman-hook-kernel-install/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = pacman-hook-kernel-install
 	pkgdesc = Pacman hooks for kernel-install.
-	pkgver = 0.8.0
+	pkgver = 0.9.0
 	pkgrel = 1
 	url = https://man.archlinux.org/man/kernel-install.8
 	arch = any
@@ -10,8 +10,8 @@ pkgbase = pacman-hook-kernel-install
 	source = 90-kernel-install-add.hook
 	source = 60-kernel-install-remove.hook
 	source = kernel-install.sh
-	sha256sums = f57a41012df2c4c80ec8dd47948aefe6b154407fa3ef067c1ad907d1250b2a26
-	sha256sums = 7ba732e788f321cdceb989fe4b48a587ae7973a21c172f6bfeef11fc96f3f8d4
-	sha256sums = 82bfd6c6220dcfefafb6538cebdc2aef69f7a9832d06fd94ca3368eaace71812
+	sha256sums = da21c9fcc8d0bdd519682c704f3746ddaa78b83b2c5993eedf2e940a2ea66f41
+	sha256sums = fb825e1f4831cfdc7a4cc7dd6c1b7e3ddda81f86cf421d38f8dabc6bd6cd0509
+	sha256sums = 27969e12af4ada0e5db907bbc6680990042180f52574584150acebde8db55adf
 
 pkgname = pacman-hook-kernel-install

--- a/pacman-hook-kernel-install/60-kernel-install-remove.hook
+++ b/pacman-hook-kernel-install/60-kernel-install-remove.hook
@@ -14,6 +14,6 @@ Target = usr/lib/modules/*/vmlinuz
 
 [Action]
 Description = Removing kernel and initrd from $BOOT... (kernel-install)
-When = PreTransaction
+When = PostTransaction
 Exec = /usr/share/libalpm/scripts/kernel-install.sh remove
 NeedsTargets

--- a/pacman-hook-kernel-install/90-kernel-install-add.hook
+++ b/pacman-hook-kernel-install/90-kernel-install-add.hook
@@ -5,12 +5,25 @@ Operation = Upgrade
 Operation = Remove
 Target = usr/lib/kernel/install.*
 Target = etc/kernel/install.*
+Target = usr/src/*/dkms.conf
 
 [Trigger]
 Type = Path
 Operation = Install
 Operation = Upgrade
 Target = usr/lib/modules/*/vmlinuz
+
+[Trigger]
+Type = Package
+Operation = Install
+Operation = Upgrade
+Target = systemd
+Target = amd-ucode
+Target = intel-ucode
+Target = plymouth
+Target = cryptsetup
+Target = dracut
+Target = mkinitcpio
 
 [Action]
 Description = Installing kernel and initrd to $BOOT... (kernel-install)

--- a/pacman-hook-kernel-install/PKGBUILD
+++ b/pacman-hook-kernel-install/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Sergey Zolotorev <sergey.zolotorev@gmail.com>
 
 pkgname=pacman-hook-kernel-install
-pkgver=0.8.0
+pkgver=0.9.0
 pkgrel=1
 pkgdesc="Pacman hooks for kernel-install."
 url='https://man.archlinux.org/man/kernel-install.8'
@@ -23,6 +23,6 @@ package() {
 }
 
 # sums
-sha256sums=('f57a41012df2c4c80ec8dd47948aefe6b154407fa3ef067c1ad907d1250b2a26'
-            '7ba732e788f321cdceb989fe4b48a587ae7973a21c172f6bfeef11fc96f3f8d4'
-            '82bfd6c6220dcfefafb6538cebdc2aef69f7a9832d06fd94ca3368eaace71812')
+sha256sums=('da21c9fcc8d0bdd519682c704f3746ddaa78b83b2c5993eedf2e940a2ea66f41'
+            'fb825e1f4831cfdc7a4cc7dd6c1b7e3ddda81f86cf421d38f8dabc6bd6cd0509'
+            '27969e12af4ada0e5db907bbc6680990042180f52574584150acebde8db55adf')

--- a/pacman-hook-kernel-install/PKGBUILD
+++ b/pacman-hook-kernel-install/PKGBUILD
@@ -1,5 +1,6 @@
 # Maintainer: eNV25 <env252525@gmail.com>
 # Contributor: Sergey Zolotorev <sergey.zolotorev@gmail.com>
+# Contributor: Sebastian Wiesner <sebastian@swsnr.de>
 
 pkgname=pacman-hook-kernel-install
 pkgver=0.9.0


### PR DESCRIPTION
- Use bash in the hook script and profit of its features: Use bash substitutions to extract the kernel version, and collect target kernel images into an array.  Tighten bash shell options.
- Run kernel-install remove post-transaction; this keeps kernels and initrds in place if something goes wrong while pacman installs packages.
- Run kernel-install on more occasions: Add a couple of packages related to early-boot as triggers, i.e. anything that might go into the initrd.
